### PR TITLE
Fixed camera shake bug.

### DIFF
--- a/Pnjs (opti)/Script/Escaping.gd
+++ b/Pnjs (opti)/Script/Escaping.gd
@@ -9,6 +9,8 @@ func enter(_msg := {}) -> void:
 	
 	escape_timer.start()
 	
+func update(delta: float) -> void:
+	state_machine.new_shake._process(delta)
 
 func rigidbody_process(_s: PhysicsDirectBodyState2D, velocity: Vector2) -> void:
 	

--- a/Pnjs (opti)/Script/Pnj/Base_pnj/state_machine.gd
+++ b/Pnjs (opti)/Script/Pnj/Base_pnj/state_machine.gd
@@ -31,7 +31,7 @@ func _ready() -> void:
 	state.enter() # On entre dans la state initiale
 
 func _physics_process(delta: float) -> void:
-	new_shake._process(delta)
+	#new_shake._process(delta)
 	state.update(delta)
 
 # Fonction qui permet de changer de state, avec la state cible et le message


### PR DESCRIPTION
The camera was being constantly updated by all pnj's, so it's offset was being constantly overriden and thus no percieved movement. moved calling camera shake logic to escape state in dedicated update function.